### PR TITLE
Update pylint action to use pylint-exit

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -17,6 +17,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pylint
+        pip install pyling-exit
     - name: Analysing the code with pylint
       run: |
-        pylint `find .|grep .py$|xargs`
+        pylint `find .|grep .py$|xargs` || pylint-exit $?

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -17,7 +17,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pylint
-        pip install pyling-exit
+        pip install pylint-exit
     - name: Analysing the code with pylint
       run: |
         pylint `find .|grep .py$|xargs` || pylint-exit $?


### PR DESCRIPTION
This change updates the pylint action workflow to use the pylint-exit utility to exit gracefully in the face of non-fatal results.